### PR TITLE
Bug rewriting pointers fixed within the example C++ code.

### DIFF
--- a/C++/readme.md
+++ b/C++/readme.md
@@ -29,10 +29,10 @@ Item *ROBOT = NULL;  // ROBOT is the robot item
 /// Start the RoboDK API
 void RoboDK_Start(){
     // RoboDK starts when a RoboDK object is created.
-    RoboDK *RDK = new RoboDK();    
+    RDK = new RoboDK();    
     
     // Retrieve the robot
-    Item *ROBOT = new Item(RDK->getItem("Motoman SV3"));
+    ROBOT = new Item(RDK->getItem("Motoman SV3"));
 }
 
 /// Delete RDK and ROBOT objects
@@ -45,7 +45,7 @@ void RoboDK_Test(){
     // Start RoboDK
     RoboDK_Start();
     
-    if (ROBOT == NULL || !ROBOT.Valid()){
+    if (ROBOT == NULL || !ROBOT->Valid()){
         // Something is wrong!
         return;
     }


### PR DESCRIPTION
1. There was two bugs with pointers RoboDK* and Item* within RoboDK_Start.
Locale pointers was defined and global pointers was not changing.
So that example code didn't working.
2. A little bug within line 48. Need a "->" operator, because ROBOT is pointer.

Now is fine, I tested it.
