### PR TITLE
C++ API. Bugfix for return empty item.

### DIFF
--- a/C++/robodk_api.cpp
+++ b/C++/robodk_api.cpp
@@ -2367,7 +2367,7 @@ Item RoboDK::_recv_Item(){//Item *item){
     if (_COM->bytesAvailable() < sizeof(quint64)){
         _COM->waitForReadyRead(_TIMEOUT);
         if (_COM->bytesAvailable() < sizeof(quint64)){
-            return false;
+            return item;
         }
     }
     QDataStream ds(_COM);


### PR DESCRIPTION
Return value type mismatch, which produced compilations errors on gcc and mingw compilers.
But everything was fine for msvc compillers.