### PR TITLE
CMake support for C++ API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Python/unit_tests/report.html
 **/.vs/**
 **/x64/**
 **/x86/**
+**/build/**
+**/install/**
+**/.cache/**

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # TODO: Project version
-project(robodk_api_cxx VERSION 1.0.0)
+project(robodk_api VERSION 1.0.0)
 
 # Set the install location
 set(CMAKE_INSTALL_PREFIX "../install")
@@ -13,19 +13,19 @@ find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIR
 add_library(robodk_api_cxx STATIC robodk_api.cpp)
 
 # Set the public header for the library so it can be installed
-set_target_properties(robodk_api_cxx PROPERTIES PUBLIC_HEADER robodk_api.h)
+set_target_properties(robodk_api PROPERTIES PUBLIC_HEADER robodk_api.h)
 # Set the include directories
-target_include_directories(robodk_api_cxx PUBLIC
+target_include_directories(robodk_api PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   )
 
 # Link the target to its dependent libraries
-target_link_libraries(robodk_api_cxx PUBLIC Qt5::Gui Qt5::Core Qt5::Network)
+target_link_libraries(robodk_api PUBLIC Qt5::Gui Qt5::Core Qt5::Network)
 
 # Specify where to install targets and define the EXPORT target name
-install(TARGETS robodk_api_cxx 
-  EXPORT robodk_api_cxxTargets
+install(TARGETS robodk_api 
+  EXPORT robodk_apiTargets
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -34,28 +34,28 @@ install(TARGETS robodk_api_cxx
   )
 
 # Install the exported target
-install(EXPORT robodk_api_cxxTargets
-  FILE "robodk_api_cxxTargets.cmake"
-  NAMESPACE "robodk_api_cxx::"
+install(EXPORT robodk_apiTargets
+  FILE "robodk_apiTargets.cmake"
+  NAMESPACE "robodk_api::"
   DESTINATION cmake
   )
 
 # Create the Config and Version files
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfig.cmake"
   INSTALL_DESTINATION cmake
   )
 
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfigVersion.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
   )
 
 # Install the Config and Version Files
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfig.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfigVersion.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake
   DESTINATION cmake
   )

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -59,3 +59,8 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake
   DESTINATION cmake
   )
+
+# Generate the export targets for the build tree
+export(EXPORT robodk_apiTargets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiTargets.cmake"
+  )

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.5)
+
+# TODO: Project version
+project(robodk_api)
+
+# Set the install location
+set(CMAKE_INSTALL_PREFIX "../install")
+
+# Find dependencies
+find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
+
+# TODO: Option for static vs shared
+add_library(robodk_api STATIC robodk_api.cpp)
+
+# Set the public header for the library so it can be installed
+set_target_properties(robodk_api PROPERTIES PUBLIC_HEADER robodk_api.h)
+# Set the include directories
+target_include_directories(robodk_api PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+
+# Link the target to its dependent libraries
+target_link_libraries(robodk_api PUBLIC Qt5::Gui Qt5::Core Qt5::Network)
+
+# Specify where to install targets and define the EXPORT target name
+install(TARGETS robodk_api 
+  EXPORT robodk_apiTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+  PUBLIC_HEADER DESTINATION include
+  )
+
+# Install the exported target
+install(EXPORT robodk_apiTargets
+  FILE "robodk_apiTargets.cmake"
+  NAMESPACE "robodk_api::"
+  DESTINATION cmake
+  )

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # TODO: Project version
-project(robodk_api)
+project(robodk_api VERSION 1.0.0)
 
 # Set the install location
 set(CMAKE_INSTALL_PREFIX "../install")
@@ -37,5 +37,25 @@ install(TARGETS robodk_api
 install(EXPORT robodk_apiTargets
   FILE "robodk_apiTargets.cmake"
   NAMESPACE "robodk_api::"
+  DESTINATION cmake
+  )
+
+# Create the Config and Version files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfig.cmake"
+  INSTALL_DESTINATION cmake
+  )
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
+  )
+
+# Install the Config and Version Files
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake
   DESTINATION cmake
   )

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # TODO: Project version
-project(robodk_api VERSION 1.0.0)
+project(robodk_api_cxx VERSION 1.0.0)
 
 # Set the install location
 set(CMAKE_INSTALL_PREFIX "../install")
@@ -10,22 +10,22 @@ set(CMAKE_INSTALL_PREFIX "../install")
 find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
 
 # TODO: Option for static vs shared
-add_library(robodk_api STATIC robodk_api.cpp)
+add_library(robodk_api_cxx STATIC robodk_api_cxx.cpp)
 
 # Set the public header for the library so it can be installed
-set_target_properties(robodk_api PROPERTIES PUBLIC_HEADER robodk_api.h)
+set_target_properties(robodk_api_cxx PROPERTIES PUBLIC_HEADER robodk_api_cxx.h)
 # Set the include directories
-target_include_directories(robodk_api PUBLIC
+target_include_directories(robodk_api_cxx PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   )
 
 # Link the target to its dependent libraries
-target_link_libraries(robodk_api PUBLIC Qt5::Gui Qt5::Core Qt5::Network)
+target_link_libraries(robodk_api_cxx PUBLIC Qt5::Gui Qt5::Core Qt5::Network)
 
 # Specify where to install targets and define the EXPORT target name
-install(TARGETS robodk_api 
-  EXPORT robodk_apiTargets
+install(TARGETS robodk_api_cxx 
+  EXPORT robodk_api_cxxTargets
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -34,28 +34,28 @@ install(TARGETS robodk_api
   )
 
 # Install the exported target
-install(EXPORT robodk_apiTargets
-  FILE "robodk_apiTargets.cmake"
-  NAMESPACE "robodk_api::"
+install(EXPORT robodk_api_cxxTargets
+  FILE "robodk_api_cxxTargets.cmake"
+  NAMESPACE "robodk_api_cxx::"
   DESTINATION cmake
   )
 
 # Create the Config and Version files
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfig.cmake"
   INSTALL_DESTINATION cmake
   )
 
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
   )
 
 # Install the Config and Version Files
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfig.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/robodk_apiConfigVersion.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/robodk_api_cxxConfigVersion.cmake
   DESTINATION cmake
   )

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_INSTALL_PREFIX "../install")
 find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
 
 # TODO: Option for static vs shared
-add_library(robodk_api_cxx STATIC robodk_api.cpp)
+add_library(robodk_api STATIC robodk_api.cpp)
 
 # Set the public header for the library so it can be installed
 set_target_properties(robodk_api PROPERTIES PUBLIC_HEADER robodk_api.h)

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -10,10 +10,10 @@ set(CMAKE_INSTALL_PREFIX "../install")
 find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
 
 # TODO: Option for static vs shared
-add_library(robodk_api_cxx STATIC robodk_api_cxx.cpp)
+add_library(robodk_api_cxx STATIC robodk_api.cpp)
 
 # Set the public header for the library so it can be installed
-set_target_properties(robodk_api_cxx PROPERTIES PUBLIC_HEADER robodk_api_cxx.h)
+set_target_properties(robodk_api_cxx PROPERTIES PUBLIC_HEADER robodk_api.h)
 # Set the include directories
 target_include_directories(robodk_api_cxx PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/C++/Config.cmake.in
+++ b/C++/Config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@LIB_NAME@Targets.cmake")
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
+
+check_required_components(@LIB_NAME@)

--- a/C++/Config.cmake.in
+++ b/C++/Config.cmake.in
@@ -2,7 +2,6 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@LIB_NAME@Targets.cmake")
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
 
 check_required_components(@LIB_NAME@)

--- a/C++/readme.md
+++ b/C++/readme.md
@@ -12,6 +12,20 @@ How to install
 ------------
 Just include the robodk_api.h and robodk_api.cpp files to your project.
 
+Alternative CMake Instructions
+------------
+A static lib for the RoboDK API for C++ can be built using CMake.  
+To build the library, run the following from the root C++ directory:
+```
+mkdir build
+cd build
+cmake ..
+cmake --build 
+```
+A CMake Project Configuration file is generated so this project can be easily added
+to another CMake project. Additionally, a basic top level CMakeLists file is included 
+so that the C++ portion of the api is compatible with CMake's FetchContent system.
+
 C++ Example
 ------------
 

--- a/C++/robodk_api.h
+++ b/C++/robodk_api.h
@@ -260,7 +260,7 @@
 
 #include <QtCore/QString>
 #include <QtGui/QMatrix4x4> // this should not be part of the QtGui! it is just a matrix
-#include <QtCore/QDebug>
+#include <QDebug>
 
 
 class QTcpSocket;

--- a/C++/robodk_api.h
+++ b/C++/robodk_api.h
@@ -260,7 +260,7 @@
 
 #include <QtCore/QString>
 #include <QtGui/QMatrix4x4> // this should not be part of the QtGui! it is just a matrix
-#include <QDebug>
+#include <QtCore/QDebug>
 
 
 class QTcpSocket;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(robodk_api)
+
+add_subdirectory(C++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(robodk_api)
+project(robodk_api_top)
 
 add_subdirectory(C++)


### PR DESCRIPTION
Add CMake files to build the C++ api into a static library and generate a `robodk_apiConfig.cmake` file to allow the library to be easily added to other CMake projects. 