### PR TITLE
Remove LIB_NAME variable from Config.cmake.in

### DIFF
--- a/C++/Config.cmake.in
+++ b/C++/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@LIB_NAME@Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/robodk_apiTargets.cmake")
 
 find_package(Qt5 NAMES Qt5 COMPONENTS Widgets GUI Concurrent Core Network REQUIRED)
 
-check_required_components(@LIB_NAME@)
+check_required_components(robodk_api)


### PR DESCRIPTION
This variable is not populated in the CMakeLists.txt and only worked as expected because I was setting it to the correct value unintentionally in an upstream CMake project while testing FetchContent. 