### PR TITLE
Do not install PySide2 on module load

### DIFF
--- a/Python/robodk/roboapps.py
+++ b/Python/robodk/roboapps.py
@@ -23,13 +23,20 @@
 import sys
 import time
 
-if 'ENABLE_TK' not in globals():
-    global ENABLE_TK
-    ENABLE_TK = True
+from robodk import robodialogs
 
-if 'ENABLE_QT' not in globals():
-    global ENABLE_QT
-    ENABLE_QT = True
+if robodialogs.ENABLE_QT:
+    from PySide2 import QtWidgets, QtCore, QtGui
+
+if robodialogs.ENABLE_TK:
+    if sys.version_info[0] < 3:
+        import Tkinter as tkinter
+        import tkFileDialog as filedialog
+        import tkMessageBox as messagebox
+    else:
+        import tkinter
+        from tkinter import filedialog
+        from tkinter import messagebox
 """
 App/actions control utilities.
 
@@ -318,7 +325,7 @@ def value_to_widget(value, parent):
 
     .. seealso:: :func:`~robodk.roboapps.widget_to_value`
     """
-    if ENABLE_QT:
+    if robodialogs.ENABLE_QT:
         return value_to_qt_widget(value, parent)
     else:
         return value_to_tk_widget(value, parent)
@@ -442,15 +449,7 @@ def get_robodk_theme(RDK=None):
 PySide2 / Qt utilities
 """
 
-if ENABLE_QT:
-    try:
-        from robodk.robolink import import_install
-        import_install("PySide2", "PySide2==5.15.*")
-        from PySide2 import QtCore, QtGui, QtWidgets
-    except:
-        ENABLE_QT = False
-
-if ENABLE_QT:
+if robodialogs.ENABLE_QT:
 
     def get_qt_app(robodk_icon=True, robodk_theme=True):
         """
@@ -474,7 +473,6 @@ if ENABLE_QT:
             icon_path = robolink.getPathIcon()
             from os import path
             if path.exists(icon_path):
-                import sys
                 if sys.platform.startswith('win'):
                     import ctypes
                     ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(str(app))  # Enable the taskbar icon
@@ -553,10 +551,10 @@ if ENABLE_QT:
             from robodk.robolink import Robolink
             RDK = Robolink()
 
-        #if 'OK' != RDK.Command('PluginLoad', 'App Loader'):  # Ensure the plugin is loaded
-        #    return None
-
-        img_hex = RDK.PluginCommand('App Loader', 'IconGet', icon_name)
+        if 'Addin Manager' in RDK.Command('PluginsList'):
+            img_hex = RDK.PluginCommand('Addin Manager', 'IconGet', icon_name)
+        else:
+            img_hex = RDK.PluginCommand('App Loader', 'IconGet', icon_name)
         if type(img_hex) is not str or img_hex == '':
             return None
 
@@ -805,22 +803,7 @@ if ENABLE_QT:
 Tkinter utilities
 """
 
-if ENABLE_TK:
-    import sys
-    if sys.version_info[0] < 3:
-        # Python 2.X only:
-        try:
-            import Tkinter as tkinter
-        except:
-            ENABLE_TK = False
-    else:
-        # Python 3.x only
-        try:
-            import tkinter
-        except:
-            ENABLE_TK = False
-
-if ENABLE_TK:
+if robodialogs.ENABLE_TK:
 
     def get_tk_app(robodk_icon=True, robodk_theme=True):
         """
@@ -848,7 +831,6 @@ if ENABLE_TK:
             icon_path = robolink.getPathIcon()
             from os import path
             if path.exists(icon_path):
-                import sys
                 if sys.platform.startswith('win'):
                     import ctypes
                     ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(str(app))  # Enable the taskbar icon
@@ -1342,6 +1324,9 @@ def ShowExample():
                     icon_window.setLayout(QtWidgets.QVBoxLayout())
                     icon_window.layout().addWidget(scroll_widget)
                     icon_window.exec_()
+                else:
+                    from robodk import robodialogs
+                    robodialogs.ShowMessage('No icons to display! Is the plug-in enabled?')
 
             actions = [("Show a Yes/No Message", showMessage), ("Show RoboDK Icons", showIcons)]
 
@@ -1356,8 +1341,6 @@ def ShowExample():
 
 
 def runmain():
-
-    from robodk import robodialogs
 
     ShowExample()
 

--- a/Python/robodk/robodialogs.py
+++ b/Python/robodk/robodialogs.py
@@ -21,13 +21,34 @@
 #
 # --------------------------------------------
 
-if 'ENABLE_TK' not in globals():
-    global ENABLE_TK
-    ENABLE_TK = True
+import sys
 
-if 'ENABLE_QT' not in globals():
-    global ENABLE_QT
+# robodialogs is compatible with PySide2 and tkinter. At least one must be present.
+ENABLE_QT = False
+try:
+    from PySide2 import QtWidgets, QtCore
     ENABLE_QT = True
+except:
+    pass
+
+ENABLE_TK = False
+try:
+    if sys.version_info[0] < 3:
+        import Tkinter as tkinter
+        import tkFileDialog as filedialog
+        import tkMessageBox as messagebox
+    else:
+        import tkinter
+        from tkinter import filedialog
+        from tkinter import messagebox
+    ENABLE_TK = True
+except:
+    pass
+
+if not ENABLE_TK and not ENABLE_QT:
+    s = 'PySide2 and/or tkinter is not present on the system. Please install PySide2: "python -m pip install PySide2" or "python -m pip install robodk[apps]"'
+    print(s)
+    raise ImportError(s)
 
 FILE_TYPES_ALL = ('All Files', '.*')  #: File type filter for all files
 FILE_TYPES_ROBODK = ('RoboDK Files', '.sld .rdk .robot .tool .rdka .rdkbak .rdkp .py')  #: File type filter for RoboDK files
@@ -360,25 +381,6 @@ def InputDialog(msg, value, title=None, default_button=False, default_value=None
 def _message_to_window_title(message):
     return message.split('\n', 1)[0].split('.', 1)[0].split(':', 1)[0]
 
-
-if ENABLE_TK:
-    import sys
-    if sys.version_info[0] < 3:
-        # Python 2.X only:
-        try:
-            import Tkinter as tkinter
-            import tkFileDialog as filedialog
-            import tkMessageBox as messagebox
-        except:
-            ENABLE_TK = False
-    else:
-        # Python 3.x only
-        try:
-            import tkinter
-            from tkinter import filedialog
-            from tkinter import messagebox
-        except:
-            ENABLE_TK = False
 
 if ENABLE_TK:
 
@@ -749,14 +751,6 @@ if ENABLE_TK:
             msgbox.root.destroy()
             return msgbox.returning
 
-
-if ENABLE_QT:
-    try:
-        from robodk.robolink import import_install
-        import_install("PySide2", "PySide2==5.15.*")
-        from PySide2 import QtCore, QtWidgets
-    except:
-        ENABLE_QT = False
 
 if ENABLE_QT:
 

--- a/Python/robodk/robofileio.py
+++ b/Python/robodk/robofileio.py
@@ -26,7 +26,7 @@ import time
 import os.path
 import time
 
-from . import robomath
+from robodk import robomath
 
 #----------------------------------------------------
 #--------      Generic file usage     ---------------

--- a/Python/robodk/robolink.py
+++ b/Python/robodk/robolink.py
@@ -484,7 +484,7 @@ def getPathIcon():
     return iconpath
 
 
-def import_install(module_name, pip_name=None, rdk=None, upgrade_pip=True):
+def import_install(module_name, pip_name=None, rdk=None, upgrade_pip=False):
     """Import a module by first installing it if the corresponding package is not available. If the module name does not match the pip install command, provide the pip_name for install purposes.
     Optionally, you can pass the RoboDK API Robolink object to see install progress in RoboDK's status bar.
 
@@ -508,7 +508,6 @@ def import_install(module_name, pip_name=None, rdk=None, upgrade_pip=True):
         return
 
     except ModuleNotFoundError:
-        import os
         import sys
         import subprocess
         import io
@@ -4450,7 +4449,10 @@ class Item:
             return self
 
     def Pose(self):
-        """Returns the relative pose of an object, target or reference frame. For example, the position of an object, target or reference frame with respect to its parent (the item it is attached to in the tree). For robot items, this function returns the pose of the active tool with respect to the active reference. It returns the pose as :class:`~robodk.robomath.Mat`.
+        """Returns the relative pose of an object, target or reference frame. For example, the position of an object, target or reference frame with respect to its parent (the item it is attached to in the tree).
+        For robot items, this function returns the pose of the active tool with respect to the active reference frame.
+
+        It returns the pose as :class:`~robodk.robomath.Mat`.
 
         Tip: Use a Pose_2_* function from the robodk module (such as :class:`robomath.Pose_2_KUKA`) to convert the pose to XYZABC (XYZ position in mm and ABC orientation in degrees), specific to a robot brand.
 
@@ -4526,7 +4528,10 @@ class Item:
             return self
 
     def PoseAbs(self):
-        """Return the pose (:class:`~robodk.robomath.Mat`) of this item with respect to the absolute reference frame (also know as the station reference or world coordinate system -WCS-). For example, the position of an object/frame/target with respect to the origin of the station.
+        """Return the pose (:class:`~robodk.robomath.Mat`) of this item with respect to the absolute reference frame (also know as the station reference or world coordinate system -WCS-).
+        For example, the position of an object/frame/target with respect to the origin of the station.
+
+        For robot items, this returns the pose of the robot base with respect to the origin of the station.
 
         Example:
 
@@ -6995,13 +7000,13 @@ class Item:
                 self.link._send_bytes(value)
                 self.link._check_status()
                 return True
-                
+
             elif isinstance(value, Item):
                 value = str(value.item)
-            
+
             elif isinstance(value, bool):
                 value = '1' if value else '0'
-            
+
             elif isinstance(value, robomath.Mat):
                 # Special 2D matrix write/read
                 self.link._check_connection()
@@ -7024,7 +7029,7 @@ class Item:
 
                 self.link._check_status()
                 return mat2d_list
-                
+
             else:
                 value = str(value)
             value = value.replace('\n', '<br>')

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -69,7 +69,13 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: C',
         'Programming Language :: C#',
+        'Programming Language :: C++',
         'Programming Language :: Visual Basic',
     ],
 
@@ -96,7 +102,7 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'apps': ['PySide2'],
+        'apps': ['PySide2==5.15.*'],
         'cv': ['opencv-contrib-python', 'numpy'],
         'lint': ['astroid'],
     },


### PR DESCRIPTION
PySide2 was automatically installed on the first module import.
If PySide2 is not present, it will fall back to tkinter.
To install PySide2, call pip install robodk[apps].