### PR TITLE
Add missing function declaration and additional pose conversion functions (RoboDK_C_API)

### DIFF
--- a/C/RoboDK C API/RoboDK_C_API/robodk_api_c.c
+++ b/C/RoboDK C API/RoboDK_C_API/robodk_api_c.c
@@ -1499,6 +1499,109 @@ void Mat_SetPose_KUKA(struct Mat_t *in1out, const struct XYZWPR_t in) {
 	in1out->arr16[15] = 1.0;
 }
 
+void KUKA_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in) {
+	double x = in->arr16[12];
+	double y = in->arr16[13];
+	double z = in->arr16[14];
+	double r, p, w;
+	if (in->arr16[2] > (1.0 - 1e-10))
+	{
+		p = -M_PI / 2.0;
+		r = 0.0;
+		w = atan2(-in->arr16[9], in->arr16[5]);
+	}
+	else if (in->arr16[2] < -1.0 + 1e-10)
+	{
+		p = M_PI / 2.0;
+		r = 0.0;
+		w = atan2(in->arr16[9], in->arr16[5]);
+	}
+	else
+	{
+		p = atan2(-in->arr16[2], sqrt(in->arr16[0] * in->arr16[0] + in->arr16[1] * in->arr16[1]));
+		w = atan2(in->arr16[1], in->arr16[0]);
+		r = atan2(in->arr16[6], in->arr16[10]);
+	}
+	in1out->arr6[0] = x;
+	in1out->arr6[1] = y;
+	in1out->arr6[2] = z;
+	in1out->arr6[3] = w * 180.0 / M_PI;
+	in1out->arr6[4] = p * 180.0 / M_PI;
+	in1out->arr6[5] = r * 180.0 / M_PI;
+}
+
+void Mat_SetPose_XYZRPW(struct Mat_t* in1out, const struct XYZWPR_t in) {
+	double x = in.arr6[0];
+	double y = in.arr6[1];
+	double z = in.arr6[2];
+	double r = in.arr6[3];
+	double p = in.arr6[4];
+	double w = in.arr6[5];
+
+	double a = r * M_PI / 180.0;
+	double b = p * M_PI / 180.0;
+	double c = w * M_PI / 180.0;
+
+	double ca = cos(a);
+	double sa = sin(a);
+	double cb = cos(b);
+	double sb = sin(b);
+	double cc = cos(c);
+	double sc = sin(c);
+
+	in1out->arr16[0] = cb * cc;
+	in1out->arr16[4] = cc * sa * sb - ca * sc;
+	in1out->arr16[8] = sa * sc + ca * cc * sb;
+	in1out->arr16[12] = x;
+
+	in1out->arr16[1] = cb * sc;
+	in1out->arr16[5] = ca * cc + sa * sb * sc;
+	in1out->arr16[9] = ca * sb * sc - cc * sa;
+	in1out->arr16[13] = y;
+
+	in1out->arr16[2] = -sb;
+	in1out->arr16[6] = cb * sa;
+	in1out->arr16[10] = ca * cb;
+	in1out->arr16[14] = z;
+
+	in1out->arr16[3] = 0.0;
+	in1out->arr16[7] = 0.0;
+	in1out->arr16[11] = 0.0;
+	in1out->arr16[15] = 1.0;
+}
+
+void XYZRPW_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in)
+{
+	double x = in->arr16[12];
+	double y = in->arr16[13];
+	double z = in->arr16[14];
+	double r, p, w;
+	if (in->arr16[2] > 1.0 - 1e-10)
+	{
+		p = -M_PI / 2.0;
+		r = 0.0;
+		w = atan2(-in->arr16[9], in->arr16[5]);
+	}
+	else if (in->arr16[2] < -1.0 + 1e-10)
+	{
+		p = M_PI / 2.0;
+		r = 0.0;
+		w = atan2(in->arr16[9], in->arr16[5]);
+	}
+	else
+	{
+		p = atan2(-in->arr16[2], sqrt(in->arr16[0] * in->arr16[0] + in->arr16[1] * in->arr16[1]));
+		w = atan2(in->arr16[1], in->arr16[0]);
+		r = atan2(in->arr16[6], in->arr16[10]);
+	}
+	in1out->arr6[0] = x;
+	in1out->arr6[1] = y;
+	in1out->arr6[2] = z;
+	in1out->arr6[3] = r * 180.0 / M_PI;
+	in1out->arr6[4] = p * 180.0 / M_PI;
+	in1out->arr6[5] = w * 180.0 / M_PI;
+}
+
 void Mat_Get_VX(const struct Mat_t *inst, struct XYZ_t *out) {
 	out->arr3[0] = inst->arr16[0];
 	out->arr3[1] = inst->arr16[1];

--- a/C/RoboDK C API/RoboDK_C_API/robodk_api_c.c
+++ b/C/RoboDK C API/RoboDK_C_API/robodk_api_c.c
@@ -1499,29 +1499,28 @@ void Mat_SetPose_KUKA(struct Mat_t *in1out, const struct XYZWPR_t in) {
 	in1out->arr16[15] = 1.0;
 }
 
-void KUKA_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in) {
+void KUKA_SetPose_Mat(struct XYZWPR_t *in1out, const struct Mat_t *in) {
 	double x = in->arr16[12];
 	double y = in->arr16[13];
 	double z = in->arr16[14];
 	double r, p, w;
-	if (in->arr16[2] > (1.0 - 1e-10))
-	{
+
+	if (in->arr16[2] > (1.0 - 1e-10)) {
 		p = -M_PI / 2.0;
 		r = 0.0;
 		w = atan2(-in->arr16[9], in->arr16[5]);
-	}
-	else if (in->arr16[2] < -1.0 + 1e-10)
-	{
+	} 
+	else if (in->arr16[2] < -1.0 + 1e-10) {
 		p = M_PI / 2.0;
 		r = 0.0;
 		w = atan2(in->arr16[9], in->arr16[5]);
-	}
-	else
-	{
+	} 
+	else {
 		p = atan2(-in->arr16[2], sqrt(in->arr16[0] * in->arr16[0] + in->arr16[1] * in->arr16[1]));
 		w = atan2(in->arr16[1], in->arr16[0]);
 		r = atan2(in->arr16[6], in->arr16[10]);
 	}
+
 	in1out->arr6[0] = x;
 	in1out->arr6[1] = y;
 	in1out->arr6[2] = z;
@@ -1530,7 +1529,7 @@ void KUKA_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in) {
 	in1out->arr6[5] = r * 180.0 / M_PI;
 }
 
-void Mat_SetPose_XYZRPW(struct Mat_t* in1out, const struct XYZWPR_t in) {
+void Mat_SetPose_XYZRPW(struct Mat_t *in1out, const struct XYZWPR_t in) {
 	double x = in.arr6[0];
 	double y = in.arr6[1];
 	double z = in.arr6[2];
@@ -1570,30 +1569,28 @@ void Mat_SetPose_XYZRPW(struct Mat_t* in1out, const struct XYZWPR_t in) {
 	in1out->arr16[15] = 1.0;
 }
 
-void XYZRPW_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in)
-{
+void XYZRPW_SetPose_Mat(struct XYZWPR_t *in1out, const struct Mat_t *in) {
 	double x = in->arr16[12];
 	double y = in->arr16[13];
 	double z = in->arr16[14];
 	double r, p, w;
-	if (in->arr16[2] > 1.0 - 1e-10)
-	{
+
+	if (in->arr16[2] > 1.0 - 1e-10) {
 		p = -M_PI / 2.0;
 		r = 0.0;
 		w = atan2(-in->arr16[9], in->arr16[5]);
-	}
-	else if (in->arr16[2] < -1.0 + 1e-10)
-	{
+	} 
+	else if (in->arr16[2] < -1.0 + 1e-10) {
 		p = M_PI / 2.0;
 		r = 0.0;
 		w = atan2(in->arr16[9], in->arr16[5]);
-	}
-	else
-	{
+	} 
+	else {
 		p = atan2(-in->arr16[2], sqrt(in->arr16[0] * in->arr16[0] + in->arr16[1] * in->arr16[1]));
 		w = atan2(in->arr16[1], in->arr16[0]);
 		r = atan2(in->arr16[6], in->arr16[10]);
 	}
+
 	in1out->arr6[0] = x;
 	in1out->arr6[1] = y;
 	in1out->arr6[2] = z;

--- a/C/RoboDK C API/RoboDK_C_API/robodk_api_c.h
+++ b/C/RoboDK C API/RoboDK_C_API/robodk_api_c.h
@@ -439,6 +439,9 @@ void Mat_Multiply_rotxyz(struct Mat_t *in1out, const double rx, const double ry,
 bool Mat_isHomogeneous(const struct Mat_t *inst);
 void Mat_SetPos(struct Mat_t *in1out, const double x, const double y, const double z);
 void Mat_SetPose_KUKA(struct Mat_t *in1out, const struct XYZWPR_t in);
+void KUKA_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in);
+void Mat_SetPose_XYZRPW(struct Mat_t* in1out, const struct XYZWPR_t in);
+void XYZRPW_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in);
 void Mat_Get_VX(const struct Mat_t *inst, struct XYZ_t *out);
 void Mat_Get_VY(const struct Mat_t *inst, struct XYZ_t *out);
 void Mat_Get_VZ(const struct Mat_t *inst, struct XYZ_t *out);

--- a/C/RoboDK C API/RoboDK_C_API/robodk_api_c.h
+++ b/C/RoboDK C API/RoboDK_C_API/robodk_api_c.h
@@ -439,9 +439,9 @@ void Mat_Multiply_rotxyz(struct Mat_t *in1out, const double rx, const double ry,
 bool Mat_isHomogeneous(const struct Mat_t *inst);
 void Mat_SetPos(struct Mat_t *in1out, const double x, const double y, const double z);
 void Mat_SetPose_KUKA(struct Mat_t *in1out, const struct XYZWPR_t in);
-void KUKA_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in);
-void Mat_SetPose_XYZRPW(struct Mat_t* in1out, const struct XYZWPR_t in);
-void XYZRPW_SetPose_Mat(struct XYZWPR_t* in1out, const struct Mat_t* in);
+void KUKA_SetPose_Mat(struct XYZWPR_t *in1out, const struct Mat_t *in);
+void Mat_SetPose_XYZRPW(struct Mat_t *in1out, const struct XYZWPR_t in);
+void XYZRPW_SetPose_Mat(struct XYZWPR_t *in1out, const struct Mat_t *in);
 void Mat_Get_VX(const struct Mat_t *inst, struct XYZ_t *out);
 void Mat_Get_VY(const struct Mat_t *inst, struct XYZ_t *out);
 void Mat_Get_VZ(const struct Mat_t *inst, struct XYZ_t *out);

--- a/C/RoboDK C API/RoboDK_C_API/robodk_api_c.h
+++ b/C/RoboDK C API/RoboDK_C_API/robodk_api_c.h
@@ -318,7 +318,7 @@ void RoboDK_Update(struct RoboDK_t* inst);
 bool RoboDK_IsInside(struct RoboDK_t* inst, struct Item_t* object_inside, struct Item_t* object_parent);
 uint32_t RoboDK_SetCollisionActive(struct RoboDK_t* inst, enum eCollisionState check_state);
 uint32_t RoboDK_Collision(struct RoboDK_t* inst, struct Item_t* item1, struct Item_t* item2);
-
+int RoboDK_Collisions(struct RoboDK_t* inst);
 
 
 


### PR DESCRIPTION
Some additions for RoboDK_C_API:
- **Commit 91ea4f5: fixes issue #109**
    Added declaration `int RoboDK_Collisions(struct RoboDK_t* inst);` in header. This function can now be used without compilation errors.
- **Commit 21b2b61: Ported pose conversion functions from RoboDK Python API**
    Added functions `KUKA_SetPose_Mat()`, `Mat_SetPose_XYZRPW()` and `XYZRPW_SetPose_Mat()` to enable further conversion between matrices and XYZRPW (default and KUKA). The implementations are ported from RoboDK's python API (robodk.robomath).
    

