### PR TITLE
Fix README.md/readme.md case mismatch in Python folder

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -11,7 +11,7 @@ from pathlib import Path
 VERSION = '5.9.4'
 
 this_directory = Path(__file__).parent
-LONG_DESCRIPTION = (this_directory / "README.md").read_text()
+LONG_DESCRIPTION = (this_directory / "readme.md").read_text()
 
 setup(
     name='robodk',

--- a/Python/tools/python2.py
+++ b/Python/tools/python2.py
@@ -114,7 +114,7 @@ def main():
     src_dirs = []
     src_dirs.append((curr_dir / '../robodk').resolve())
     src_dirs.append((curr_dir / '../robolink').resolve())
-    src_dirs.append((curr_dir / '../README.md').resolve())
+    src_dirs.append((curr_dir / '../readme.md').resolve())
     src_dirs.append((curr_dir / '../LICENSE').resolve())
     src_dirs.append((curr_dir / '../MANIFEST.in').resolve())
     src_dirs.append((curr_dir / '../setup.py').resolve())


### PR DESCRIPTION
## Summary

The Python package's readme file is named `readme.md` (lowercase), but two files in the `Python/` folder reference it as `README.md` (uppercase):

- `Python/setup.py:14` — `(this_directory / "README.md").read_text()`
- `Python/tools/python2.py:117` — `(curr_dir / '../README.md').resolve()`

On case-sensitive filesystems (e.g. Linux), this mismatch causes failures:
- `setup.py` raises `FileNotFoundError` when building the long description from the readme.
- `tools/python2.py` fails to copy the readme into the Python 2 build folder.

## Change

Update both references to use the actual filename `readme.md`.